### PR TITLE
Updating build process for 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,39 @@ To add the admin user account on initial deployment, use the /admin web interfac
 Building From Source
 --------------------
 
+Prerequisits as of Jun. 17, 2020:
+
+```sh
+# Download org.powermock.api:powermock-api-easymock:jar:1.4.5 manually
+mkdir -p ~/.m2/repository/org/powermock/api/powermock-api-easymock/1.4.5
+pushd ~/.m2/repository/org/powermock/api/powermock-api-easymock/1.4.5
+wget http://www.java2s.com/Code/JarDownload/powermock-easymock/powermock-easymock-1.4.5-full.jar.zip
+unzip powermock-easymock-1.4.5-full.jar.zip
+mv powermock-easymock-1.4.5-full.jar powermock-easymock-1.4.5.jar
+mkdir tmp && cd tmp
+jar xf ../powermock-easymock-1.4.5.jar
+mv META-INF/maven/org.powermock.api/powermock-api-easymock/pom.xml ../powermock-api-easymock-1.4.5.pom
+cd ..
+rm -rf tmp
+
+# Change javassist:javassist:jar:3.13.0.GA to org.javassist:javassist:jar:3.13.0-GA so it can be found in Maven Central
+sed -ie 's/<groupId>javassist/<groupId>org.javassist/' ../../../powermock-core/1.4.5/powermock-core-1.4.5.pom
+sed -ie 's/3.13.0.GA/3.13.0-GA/' ../../../powermock-core/1.4.5/powermock-core-1.4.5.pom
+
+# Build supersimpledb, tbh don't know if this actually functions or on what version of Java
+mkdir -p ~/.m2/repository/com/janrain/commons/supersimpledb/commons-supersimpledb/1.0.27/
+cd ~/.m2/repository/com/janrain/commons/supersimpledb/commons-supersimpledb/1.0.27/
+git clone git@github.com:janrain/supersimpledb.git
+cd supersimpledb
+mvn package -DskipTests=true
+mv pom.xml ../commons-supersimpledb-1.0.27.pom
+mv target/commons-supersimpledb-1.0.28-SNAPSHOT.jar ../commons-supersimpledb-1.0.28.jar
+cd ..
+rm -rf supersimpledb
+
+popd
+```
+
 This project requires the [Maven] [3] build tool.
 
         mvn package -DskipTests=true

--- a/pom.xml
+++ b/pom.xml
@@ -283,8 +283,8 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <!-- patched version -->
-            <version>2.1.0.a</version>
+            <!-- patched version was a but it's missing -->
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.netflix.curator</groupId>
@@ -347,7 +347,11 @@
         <!-- Test tools respositories -->
         <repository>
             <id>powermock-repo</id>
-            <url>http://powermock.googlecode.com/svn/repo/</url>
+            <url>https://packages.atlassian.com/maven-3rdparty-legacy/</url>
+        </repository>
+        <repository>
+            <id>maven-central</id>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
         <repository>
             <id>maven2-repository.dev.java.net</id>
@@ -355,11 +359,7 @@
             <url>http://download.java.net/maven/2/</url>
             <layout>default</layout>
         </repository>
-        <!-- Coda Hale's Metrics repo -->
-        <repository>
-            <id>repo.codahale.com</id>
-            <url>http://repo.codahale.com</url>
-        </repository>
+
         <!-- Scala plugin repo -->
         <repository>
             <id>scala</id>
@@ -372,11 +372,6 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-        <!-- Janrain's supersimpledb dependency -->
-        <repository>
-            <id>janrain-repo</id>
-            <url>https://repository-janrain.forge.cloudbees.com/release</url>
-        </repository>
 
         <repository>
             <id>spy</id>
@@ -388,10 +383,6 @@
             </snapshots>
         </repository>
 
-        <repository>
-            <id>codehaus-release</id>
-            <url>http://repository.codehaus.org</url>
-        </repository>
         <!-- For flume -->
         <repository>
           <id>cloudera</id>


### PR DESCRIPTION
Several repos were dead, cloudbees repo seems to be dead and I checked the jfrog repo but the redis.clients:jedis patch and the supersimpledb artifacts weren't there. Found replacements for the rest and documented how to build/install supersimpledb manually.

Note: this isn't really meant to be merged, more just acting as documentation. Obviously this would need a lot more work to be actually usable.